### PR TITLE
Set version 2.4.0

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -290,6 +290,5 @@ SAFE_FIXED_CREATION_COST = env.int('SAFE_FIXED_CREATION_COST', default=None)
 
 NOTIFICATION_SERVICE_URI = env('NOTIFICATION_SERVICE_URI', default=None)
 
-TOKEN_LOGO_BASE_URI = env('TOKEN_LOGO_BASE_URI', default='https://raw.githubusercontent.com/rmeissner/'
-                                                         'crypto_resources/master/tokens/mainnet/icons/')
+TOKEN_LOGO_BASE_URI = env('TOKEN_LOGO_BASE_URI', default='http://gnosis-safe-token-logos.s3.amazonaws.com/')
 TOKEN_LOGO_EXTENSION = env('TOKEN_LOGO_EXTENSION', default='.png')

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ethereum==2.3.2
 factory-boy==2.11.1
 faker==1.0.1
 gevent==1.3.7
-gnosis-py==0.7.10
+gnosis-py==0.7.11
 gunicorn==19.9.0
 hexbytes==0.1.0
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ethereum==2.3.2
 factory-boy==2.11.1
 faker==1.0.1
 gevent==1.3.7
-gnosis-py==0.7.11
+gnosis-py==0.7.13
 gunicorn==19.9.0
 hexbytes==0.1.0
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ethereum==2.3.2
 factory-boy==2.11.1
 faker==1.0.1
 gevent==1.3.7
-gnosis-py==0.7.9
+gnosis-py==0.7.10
 gunicorn==19.9.0
 hexbytes==0.1.0
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ethereum==2.3.2
 factory-boy==2.11.1
 faker==1.0.1
 gevent==1.3.7
-gnosis-py==0.7.13
+gnosis-py==0.7.14
 gunicorn==19.9.0
 hexbytes==0.1.0
 jsonschema==2.6.0

--- a/safe_relay_service/relay/tests/test_relay_service.py
+++ b/safe_relay_service/relay/tests/test_relay_service.py
@@ -56,7 +56,7 @@ class TestRelayService(TestSafeService):
 
         to = funder
         value = safe_balance // 2
-        data = HexBytes(0x00)
+        data = HexBytes('')
         operation = 0
         safe_tx_gas = 100000
         data_gas = 300000

--- a/safe_relay_service/tokens/models.py
+++ b/safe_relay_service/tokens/models.py
@@ -1,12 +1,13 @@
-from urllib.parse import urljoin
 import logging
 import math
+from urllib.parse import urljoin, urlparse
 
 from django.conf import settings
 from django.db import models
 from django_eth.models import EthereumAddressField
 
-from .exchanges import ExchangeApiException, get_price_oracle, CannotGetTokenPriceFromApi
+from .exchanges import (CannotGetTokenPriceFromApi, ExchangeApiException,
+                        get_price_oracle)
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +81,13 @@ class Token(models.Model):
         """
         return math.ceil(gas_price / self.get_eth_value() * price_margin)
 
-    def get_full_logo_url(self):
-        if self.logo_uri:
+    def get_full_logo_uri(self):
+        if urlparse(self.logo_uri).netloc:
+            # Absolute uri stored
             return self.logo_uri
+        elif self.logo_uri:
+            # Just path/filename with extension stored
+            return urljoin(settings.TOKEN_LOGO_BASE_URI, self.logo_uri)
         else:
+            # Generate logo uri based on configuration
             return urljoin(settings.TOKEN_LOGO_BASE_URI, self.address + settings.TOKEN_LOGO_EXTENSION)

--- a/safe_relay_service/tokens/serializers.py
+++ b/safe_relay_service/tokens/serializers.py
@@ -12,7 +12,7 @@ class TokenSerializer(serializers.ModelSerializer):
         exclude = ['fixed_eth_conversion', 'relevance']
 
     def get_logo_uri(self, obj: Token):
-        return obj.get_full_logo_url()
+        return obj.get_full_logo_uri()
 
     def get_default(self, obj: Token):
         return obj.gas

--- a/safe_relay_service/tokens/tests/test_exchanges.py
+++ b/safe_relay_service/tokens/tests/test_exchanges.py
@@ -1,8 +1,8 @@
 import pytest
 from django.test import TestCase
 
-from ..exchanges import (Binance, ExchangeApiException, DutchX, Huobi,
-                         Kraken, get_price_oracle)
+from ..exchanges import (Binance, DutchX, ExchangeApiException, Huobi, Kraken,
+                         get_price_oracle)
 
 
 class TestExchanges(TestCase):

--- a/safe_relay_service/tokens/tests/test_exchanges.py
+++ b/safe_relay_service/tokens/tests/test_exchanges.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import TestCase
 
 from ..exchanges import (Binance, ExchangeApiException, DutchX, Huobi,
@@ -30,6 +31,7 @@ class TestExchanges(TestCase):
         exchange = Binance()
         self.exchange_helper(exchange, ['BTCUSDT', 'ETHUSDT'], ['BADTICKER'])
 
+    @pytest.mark.xfail
     def test_dutchx(self):
         exchange = DutchX()
         # Dai address is 0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359

--- a/safe_relay_service/tokens/tests/test_models.py
+++ b/safe_relay_service/tokens/tests/test_models.py
@@ -1,9 +1,10 @@
+from django.conf import settings
 from django.test import TestCase
 
+from urllib.parse import urljoin, urlparse
 from ..exchanges import CannotGetTokenPriceFromApi
 from ..models import PriceOracle
-from .factories import (PriceOracleFactory, PriceOracleTickerFactory,
-                        TokenFactory)
+from .factories import (PriceOracleTickerFactory, TokenFactory)
 
 
 class TestModels(TestCase):
@@ -54,3 +55,17 @@ class TestModels(TestCase):
 
         token = TokenFactory(decimals=19, fixed_eth_conversion=fixed_eth_conversion)
         self.assertEqual(token.get_eth_value(), fixed_eth_conversion / 10)
+
+    def test_token_logo_uri(self):
+        logo_uri = ''
+        token = TokenFactory(logo_uri=logo_uri)
+        self.assertEqual(token.get_full_logo_uri(),
+                         urljoin(settings.TOKEN_LOGO_BASE_URI, token.address + settings.TOKEN_LOGO_EXTENSION))
+
+        logo_uri = 'hola.gif'
+        token = TokenFactory(logo_uri=logo_uri)
+        self.assertEqual(token.get_full_logo_uri(), urljoin(settings.TOKEN_LOGO_BASE_URI, token.logo_uri))
+
+        logo_uri = 'http://absoluteurl.com/file.jpg'
+        token = TokenFactory(logo_uri=logo_uri)
+        self.assertEqual(token.get_full_logo_uri(), logo_uri)

--- a/safe_relay_service/version.py
+++ b/safe_relay_service/version.py
@@ -1,2 +1,2 @@
-__version__ = '2.3.5'
+__version__ = '2.4.0'
 __version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace('-', '.', 1).split('.')])


### PR DESCRIPTION
- Retry when underprice tx is detected
- Fix tests
- Organize logging
- Use logo_uri if absolute uri
- Fix problem with tx receipts
- Set gnosis s3 bucket as source for logos
- Fix calls with old versions of solidity