### PR TITLE
Allow non relay safes

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==5.3.2
+pytest==5.3.5
 pytest-django==3.8.0
 pytest-sugar==0.9.2
 coverage==4.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ lxml==4.4.1
 numpy==1.18.1
 packaging>=19.0
 psycopg2-binary==2.8.4
-redis==3.3.11
+redis==3.4.1
 requests==2.22.0
 web3==5.4.0

--- a/safe_relay_service/relay/tests/test_views.py
+++ b/safe_relay_service/relay/tests/test_views.py
@@ -19,7 +19,7 @@ from gnosis.safe.signatures import signatures_to_bytes
 from safe_relay_service.gas_station.tests.factories import GasPriceFactory
 from safe_relay_service.tokens.tests.factories import TokenFactory
 
-from ..models import SafeMultisigTx
+from ..models import SafeMultisigTx, SafeContract
 from .factories import (EthereumEventFactory, EthereumTxFactory,
                         InternalTxFactory, SafeContractFactory,
                         SafeCreation2Factory, SafeMultisigTxFactory)
@@ -197,6 +197,53 @@ class TestViews(RelayTestCaseMixin, APITestCase):
                                     format='json')
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertTrue('exists' in response.data['exception'])
+
+        # Send with a Safe not created via the service
+        safe_creation = self.deploy_test_safe(owners=owners, threshold=threshold, initial_funding_wei=safe_balance)
+        my_safe_address = safe_creation.safe_address
+        multisig_tx_hash = SafeTx(
+            None,
+            my_safe_address,
+            to,
+            value,
+            tx_data,
+            operation,
+            safe_tx_gas,
+            data_gas,
+            gas_price,
+            gas_token,
+            refund_receiver,
+            safe_nonce=nonce
+        ).safe_tx_hash
+        signatures = [account.signHash(multisig_tx_hash) for account in accounts]
+        signatures_json = [{'v': s['v'], 'r': s['r'], 's': s['s']} for s in signatures]
+        data['signatures'] = signatures_json
+
+        with self.assertRaises(SafeContract.DoesNotExist):
+            SafeContract.objects.get(address=my_safe_address)
+
+        response = self.client.post(reverse('v1:safe-multisig-txs', args=(my_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(SafeContract.objects.filter(address=my_safe_address).exists())
+        self.assertEqual(SafeMultisigTx.objects.filter(safe_id=my_safe_address).count(), 1)
+
+        # Send the same tx again
+        response = self.client.post(reverse('v1:safe-multisig-txs', args=(my_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertTrue('exists' in response.data['exception'])
+        self.assertEqual(SafeMultisigTx.objects.filter(safe_id=my_safe_address).count(), 1)
+
+        # Send tx with not existing Safe
+        my_safe_address = Account.create().address
+        response = self.client.post(reverse('v1:safe-multisig-txs', args=(my_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertTrue('InvalidProxyContract' in response.data['exception'])
 
     def test_safe_multisig_tx_get(self):
         safe = SafeContractFactory()
@@ -400,7 +447,6 @@ class TestViews(RelayTestCaseMixin, APITestCase):
 
         safe_creation = self.deploy_test_safe(number_owners=3, threshold=2, initial_funding_wei=initial_funding)
         my_safe_address = safe_creation.safe_address
-        SafeContractFactory(address=my_safe_address)
 
         response = self.client.post(reverse('v1:safe-multisig-tx-estimate', args=(my_safe_address,)),
                                     data=data,
@@ -413,7 +459,20 @@ class TestViews(RelayTestCaseMixin, APITestCase):
         self.assertIsNone(response['lastUsedNonce'])
         self.assertEqual(response['gasToken'], NULL_ADDRESS)
 
-        to, _ = get_eth_address_with_key()
+        # Add to the database and check again
+        SafeContractFactory(address=my_safe_address)
+        response = self.client.post(reverse('v1:safe-multisig-tx-estimate', args=(my_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = response.json()
+        self.assertGreater(response['safeTxGas'], 0)
+        self.assertGreater(response['dataGas'], 0)
+        self.assertGreater(response['gasPrice'], 0)
+        self.assertIsNone(response['lastUsedNonce'])
+        self.assertEqual(response['gasToken'], NULL_ADDRESS)
+
+        to = Account.create().address
         data = {
             'to': to,
             'value': initial_funding // 2,
@@ -424,6 +483,14 @@ class TestViews(RelayTestCaseMixin, APITestCase):
                                     data=data,
                                     format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Use not existing safe
+        my_safe_address = Account.create().address
+        response = self.client.post(reverse('v1:safe-multisig-tx-estimate', args=(my_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("SafeDoesNotExist", response.data['exception'])
 
     def test_safe_multisig_tx_estimates(self):
         my_safe_address = get_eth_address_with_invalid_checksum()
@@ -442,7 +509,6 @@ class TestViews(RelayTestCaseMixin, APITestCase):
 
         safe_creation = self.deploy_test_safe(number_owners=3, threshold=2, initial_funding_wei=initial_funding)
         my_safe_address = safe_creation.safe_address
-        SafeContractFactory(address=my_safe_address)
 
         to = Account.create().address
         tx = {
@@ -451,6 +517,21 @@ class TestViews(RelayTestCaseMixin, APITestCase):
             'data': '0x',
             'operation': 1
         }
+        response = self.client.post(reverse('v1:safe-multisig-tx-estimates', args=(my_safe_address,)),
+                                    data=tx,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Use not existing Safe
+        non_existing_safe_address = Account.create().address
+        response = self.client.post(reverse('v1:safe-multisig-tx-estimates', args=(non_existing_safe_address,)),
+                                    data=tx,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("SafeDoesNotExist", response.data['exception'])
+
+        # Add to database and test
+        SafeContractFactory(address=my_safe_address)
         response = self.client.post(reverse('v1:safe-multisig-tx-estimates', args=(my_safe_address,)),
                                     data=tx,
                                     format='json')

--- a/safe_relay_service/relay/tests/test_views.py
+++ b/safe_relay_service/relay/tests/test_views.py
@@ -370,12 +370,6 @@ class TestViews(RelayTestCaseMixin, APITestCase):
                                     format='json')
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-        my_safe_address, _ = get_eth_address_with_key()
-        response = self.client.post(reverse('v1:safe-multisig-txs', args=(my_safe_address,)),
-                                    data={},
-                                    format='json')
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
         my_safe_address = self.create2_test_safe_in_db().safe.address
         response = self.client.post(reverse('v1:safe-multisig-txs', args=(my_safe_address,)),
                                     data={},
@@ -393,7 +387,7 @@ class TestViews(RelayTestCaseMixin, APITestCase):
         response = self.client.post(reverse('v1:safe-multisig-tx-estimate', args=(my_safe_address,)),
                                     data={},
                                     format='json')
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         initial_funding = self.w3.toWei(0.0001, 'ether')
         to, _ = get_eth_address_with_key()
@@ -442,7 +436,7 @@ class TestViews(RelayTestCaseMixin, APITestCase):
         response = self.client.post(reverse('v1:safe-multisig-tx-estimates', args=(my_safe_address,)),
                                     data={},
                                     format='json')
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         initial_funding = self.w3.toWei(0.0001, 'ether')
 

--- a/safe_relay_service/relay/tests/test_views.py
+++ b/safe_relay_service/relay/tests/test_views.py
@@ -19,7 +19,7 @@ from gnosis.safe.signatures import signatures_to_bytes
 from safe_relay_service.gas_station.tests.factories import GasPriceFactory
 from safe_relay_service.tokens.tests.factories import TokenFactory
 
-from ..models import SafeMultisigTx, SafeContract
+from ..models import SafeContract, SafeMultisigTx
 from .factories import (EthereumEventFactory, EthereumTxFactory,
                         InternalTxFactory, SafeContractFactory,
                         SafeCreation2Factory, SafeMultisigTxFactory)

--- a/safe_relay_service/relay/tests/test_views_v2.py
+++ b/safe_relay_service/relay/tests/test_views_v2.py
@@ -187,7 +187,7 @@ class TestViewsV2(RelayTestCaseMixin, APITestCase):
         response = self.client.post(reverse('v2:safe-multisig-tx-estimate', args=(my_safe_address,)),
                                     data={},
                                     format='json')
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         initial_funding = self.w3.toWei(0.0001, 'ether')
         to = Account.create().address

--- a/safe_relay_service/relay/tests/test_views_v2.py
+++ b/safe_relay_service/relay/tests/test_views_v2.py
@@ -200,8 +200,22 @@ class TestViewsV2(RelayTestCaseMixin, APITestCase):
 
         safe_creation = self.deploy_test_safe(number_owners=3, threshold=2, initial_funding_wei=initial_funding)
         my_safe_address = safe_creation.safe_address
-        SafeContractFactory(address=my_safe_address)
 
+        response = self.client.post(reverse('v2:safe-multisig-tx-estimate', args=(my_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Use non existing Safe
+        non_existing_safe_address = Account.create().address
+        response = self.client.post(reverse('v2:safe-multisig-tx-estimate', args=(non_existing_safe_address,)),
+                                    data=data,
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertIn("SafeDoesNotExist", response.data['exception'])
+
+        # Add to database and test again
+        SafeContractFactory(address=my_safe_address)
         response = self.client.post(reverse('v2:safe-multisig-tx-estimate', args=(my_safe_address,)),
                                     data=data,
                                     format='json')

--- a/safe_relay_service/relay/views_v2.py
+++ b/safe_relay_service/relay/views_v2.py
@@ -100,11 +100,6 @@ class SafeMultisigTxEstimateView(CreateAPIView):
         """
         if not Web3.isChecksumAddress(address):
             return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
-        else:
-            try:
-                SafeContract.objects.get(address=address)
-            except SafeContract.DoesNotExist:
-                return Response(status=status.HTTP_404_NOT_FOUND)
 
         request.data['safe'] = address
         serializer = self.get_serializer_class()(data=request.data)

--- a/safe_relay_service/relay/views_v2.py
+++ b/safe_relay_service/relay/views_v2.py
@@ -82,8 +82,7 @@ class SafeCreationView(CreateAPIView):
             safe_creation_response_data.is_valid(raise_exception=True)
             return Response(status=status.HTTP_201_CREATED, data=safe_creation_response_data.data)
         else:
-            return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                            data=serializer.errors)
+            return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY, data=serializer.errors)
 
 
 class SafeMultisigTxEstimateView(CreateAPIView):


### PR DESCRIPTION
- Closes #185 
- Remove checks to prevent non relay Safes using the service
- Refactor some code depending on database models
- Auto register Safe if it didn't use the relay before
- Refactor and add new tests