### PR TITLE
Changing docker container name for createSuperUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ curl 'http://localhost:8000/api/v1/about/'
 Services come with a basic administration web ui (provided by Django). A user must be created first to
 get access:
 ```bash
-docker exec -it safe-transaction-service_web_1 bash
+docker exec -it safe-relay-service_worker_1 bash
 python manage.py createsuperuser
 ```
 


### PR DESCRIPTION
Container name doesn't exist. Verified in docker-compose files. Changing name to what's created by docker-compose up. `safe-relay-service_worker_1`