### PR TITLE
Fixes #260 allowing existing foward proto

### DIFF
--- a/docker/nginx/safe_service.conf
+++ b/docker/nginx/safe_service.conf
@@ -27,6 +27,11 @@ http {
       # server web:8000 fail_timeout=0;
     }
 
+    map $http_x_forwarded_proto $forward_proto {
+      default $scheme;
+      https "https";
+    }
+
     server {
         listen 8000 deferred;
         client_max_body_size 75M;
@@ -51,7 +56,7 @@ http {
 
         location / {
             proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-            proxy_set_header    X-Forwarded-Proto   $scheme;
+            proxy_set_header    X-Forwarded-Proto   $forward_proto;
             proxy_set_header    Host                $host;
             # we don't want nginx trying to do something clever with
             # redirects, we set the Host: header above already.


### PR DESCRIPTION
This addresses the scenario when a `x-forward-proto` header already exists and get squashed by the nginx serving protocol.